### PR TITLE
채팅 메시지 실시간 상태 반영

### DIFF
--- a/src/pages/chat.tsx
+++ b/src/pages/chat.tsx
@@ -55,7 +55,9 @@ const Chat: NextPage = () => {
       onConnect: () => {
         client.current?.subscribe(`/topic/${user?.nickname}`, ({ body }) => {
           const message = JSON.parse(body) as Message;
-          setMessages((prev) => [...prev, message]);
+          if (currChatUser === message.sender) {
+            setMessages((prev) => [...prev, message]);
+          }
         });
       },
     });

--- a/src/pages/chat.tsx
+++ b/src/pages/chat.tsx
@@ -141,13 +141,15 @@ const Chat: NextPage = () => {
                   />
                 ))}
               </div>
-              <div className={styles.SendMessageBox}>
-                <SendMessageForm
-                  onSubmit={onSubmitForm}
-                  onChange={onChangeChat}
-                  value={chat}
-                />
-              </div>
+              {currChatUser && (
+                <div className={styles.SendMessageBox}>
+                  <SendMessageForm
+                    onSubmit={onSubmitForm}
+                    onChange={onChangeChat}
+                    value={chat}
+                  />
+                </div>
+              )}
             </div>
             <AddChatModal show={isModalOpen} onCloseModal={closeModal} />
           </div>

--- a/src/pages/chat.tsx
+++ b/src/pages/chat.tsx
@@ -6,10 +6,9 @@ import SendMessageForm from 'components/SendMessageForm';
 import type { NextPage } from 'next';
 import styles from 'styles/Chat.module.scss';
 import SockJS from 'sockjs-client';
-import { Stomp } from '@stomp/stompjs';
-import { useCallback, useEffect, useState } from 'react';
+import { Client } from '@stomp/stompjs';
+import { useEffect, useRef, useState } from 'react';
 import useUser from 'hooks/useUser';
-import axios from 'axios';
 import useInput from 'hooks/useInput';
 import useModal from 'hooks/useModal';
 import AddChatButton from 'components/AddChatButton';
@@ -17,90 +16,62 @@ import AddChatModal from 'components/AddChatModal';
 import useSWR from 'swr';
 import dayjs from 'dayjs';
 import ChatDelete from 'components/ChatDelete';
+import { Message } from 'types';
+import wsInstance, { fetcher, WEBSOCKET_URL } from 'utils/wsInstance';
 // import 'dayjs/locale/ko';
-
-export type messageInfo = {
-  message?: any;
-  sender?: string;
-  receiver: string;
-  createdDate: string;
-};
-
-let client: any = null;
-const socketUrl = 'http://localhost:8000/ws';
 
 const Chat: NextPage = () => {
   const { user } = useUser();
-  const username = user?.nickname;
   const [chat, onChangeChat, setChat] = useInput('');
   const { isModalOpen, openModal, closeModal } = useModal();
   const [currChatUser, setCurrChatUser] = useState('');
+  const [messages, setMessages] = useState<Message[]>([]);
+  const client = useRef<Client | null>(null);
 
-  const fetcher = (url: string) =>
-    axios.get(url).then((response) => response.data);
-  const fetcherDetails = (url: string) =>
-    axios.get(url).then((response) => response.data.messages);
-
-  const {
-    data: chatData,
-    //  mutate: mutateChat
-  } = useSWR(`http://localhost:8000/chat/${username}/chatrooms`, fetcher);
-
-  const { data: chatDetails } = useSWR(
-    `http://localhost:8000/chat/${username}/chatrooms/${currChatUser}/messages`,
-    fetcherDetails
+  const { data: chatData } = useSWR(
+    user ? `/chat/${user.nickname}/chatrooms` : null,
+    fetcher
   );
+
+  useEffect(() => {
+    if (!user || !currChatUser) return;
+    wsInstance
+      .get<{ messages: Message[] }>(
+        `/chat/${user.nickname}/chatrooms/${currChatUser}/messages`
+      )
+      .then(({ data }) => {
+        setMessages(data.messages);
+      });
+  }, [user, currChatUser]);
 
   // const { data: localUser } = useSWR(currChatUser, (key) => {
   //   localStorage.setItem('curUser', key);
   //   return localStorage.getItem('curUser');
   // });
 
-  const getChatRooms = useCallback(() => {
-    axios
-      .get(`http://localhost:8000/chat/${username}/chatrooms`)
-      .then((response) => {
-        console.log('response: ', response.data);
-      });
-  }, [username]);
-
   useEffect(() => {
-    getChatRooms();
-
-    const socket = new SockJS(socketUrl);
-    client = Stomp.over(socket);
-    client.connect(
-      {},
-      () => {
-        console.log('현재 ' + username);
-
-        client.subscribe('/topic/' + username, function (msg: any) {
-          _processMessage(msg.body), msg.headers.destination;
+    client.current = new Client({
+      webSocketFactory: () => new SockJS(`${WEBSOCKET_URL}/ws`),
+      onConnect: () => {
+        client.current?.subscribe(`/topic/${user?.nickname}`, ({ body }) => {
+          const message = JSON.parse(body) as Message;
+          setMessages((prev) => [...prev, message]);
         });
-        client.send('/topic/' + currChatUser, {}, JSON.stringify(chat));
       },
-      (err: Error) => {
-        console.log(err);
-      }
-    );
+    });
+    client.current.activate();
 
-    return () => client.deactivate();
-  }, [username, getChatRooms, chatData, chat, currChatUser, chatDetails]);
+    return () => {
+      client.current?.deactivate();
+    };
+  }, [user, currChatUser]);
 
-  const _processMessage = (msgBody: any) => {
-    try {
-      return JSON.parse(msgBody);
-    } catch (e) {
-      return msgBody;
-    }
-  };
-
-  const publish = (messageInfo: messageInfo) => {
-    if (!client.connected) {
+  const publish = (messageInfo: Message) => {
+    if (!client.current?.connected) {
       return;
     }
 
-    client.publish({
+    client.current.publish({
       destination: '/app/send',
       body: JSON.stringify(messageInfo),
     });
@@ -108,18 +79,23 @@ const Chat: NextPage = () => {
 
   const onSubmitForm = (e: any) => {
     e.preventDefault();
+
+    if (!chat) return;
     setChat('');
 
-    const messageInfo: messageInfo = {
+    if (!user) return;
+    const messageInfo: Message = {
       message: chat,
-      sender: username,
+      sender: user.nickname,
       receiver: currChatUser,
       createdDate: dayjs().format('HH:MM'),
     };
+    setMessages((prev) => [...prev, messageInfo]);
+
     publish(messageInfo);
-    console.log(messageInfo);
-    console.log('chatDetails: ', chatDetails);
-    console.log(dayjs().format('HH:MM'));
+    // console.log(messageInfo);
+    // console.log('messages: ', messages);
+    // console.log(dayjs().format('HH:MM'));
   };
 
   return (
@@ -153,16 +129,15 @@ const Chat: NextPage = () => {
                   <SendMessageDate date={'2022년 00월 00일 0요일'} />
                 )}
 
-                {currChatUser &&
-                  chatDetails?.map((data: any, i: number) => (
-                    <MessageBox
-                      key={i}
-                      interlocutorName={data.sender}
-                      content={data.message}
-                      time={data.createdDate}
-                      isMe={data.receiver === currChatUser ? true : false}
-                    />
-                  ))}
+                {messages.map((data: any, i: number) => (
+                  <MessageBox
+                    key={i}
+                    interlocutorName={data.sender}
+                    content={data.message}
+                    time={data.createdDate}
+                    isMe={data.receiver === currChatUser ? true : false}
+                  />
+                ))}
               </div>
               <div className={styles.SendMessageBox}>
                 <SendMessageForm

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,3 +43,10 @@ export type Post = {
   profile: MyImage;
   title: string;
 };
+
+export type Message = {
+  sender: string;
+  receiver: string;
+  message: string;
+  createdDate: string;
+};

--- a/src/utils/wsInstance.ts
+++ b/src/utils/wsInstance.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+export const WEBSOCKET_URL = 'http://localhost:8000';
+export const fetcher = (url: string) =>
+  wsInstance.get(url).then((response) => response.data);
+
+const wsInstance = axios.create({ baseURL: WEBSOCKET_URL });
+export default wsInstance;


### PR DESCRIPTION
주요 작업 내용

- 채팅 메시지 실시간으로 상태 반영
- 대화 상대 추가 후 화면 상태 갱신
- 빈 메시지 전송 안 되게 수정

기타 작업 내용
- **client를 useRef로 변경**: 컴포넌트 안에 let으로 선언하면 매번 client가 초기화되기 때문에 useRef로 한 번만 client를 생성하도록 했습니다.
- **Stomp import 방식 변경**
    : Stomp를 기존 방식처럼 불러오는 것이 Deprecated 되었다고 나와있어서 [공식 홈페이지의 예제 코드](https://stomp-js.github.io/guide/stompjs/rx-stomp/ng2-stompjs/using-stomp-with-sockjs.html#example-with-stompjs)를 참고해 수정했습니다.

    ![Pasted image 20220511143550](https://user-images.githubusercontent.com/49304239/167794333-aa4561cb-5391-4cbf-b792-298215a8a9d9.png)

미처 생각하지 못한 개선점이나 버그가 있을 수 있는데 그런 부분 있으면 바로 말씀해주세요!